### PR TITLE
📝 Fix wrong cmd to restart workers

### DIFF
--- a/exercises/debug-activity/README.md
+++ b/exercises/debug-activity/README.md
@@ -153,7 +153,7 @@ running `go test` again.
    Since Workers cache the code, the changes won't take effect until 
    they have been restarted. Do not press Ctrl-C in the terminal used
    to start the Workflow.
-2. Start both Workers by running `go run start/main.go` in their respective 
+2. Start both Workers by running `go run worker/main.go` in their respective 
    terminals.
 3. Click the **History** tab near the top of the detail page in the Web UI
 4. Click the toggle button labeled **Auto refresh** near the upper-right


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Fix the command to start workers instead of executing workflow.

## Why?
<!-- Tell your future self why have you made these changes -->
It is the wrong command.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
