### PR TITLE
📝 Fix version number for Workflow Executions started after the change.

### DIFF
--- a/exercises/version-workflow/README.md
+++ b/exercises/version-workflow/README.md
@@ -132,7 +132,7 @@ is `1`.
    called if the condition evaluates to `true`.
 3. Wrap the code you previously moved after the loop in a
    conditional statement that tests if `version` is equal to
-   `workflow.DefaultVersion`. This will handle the Activity for Workflow
+   `1`. This will handle the Activity for Workflow
    Executions started after the change.
 4. Change the duration of the `workflow.Sleep` statement at the
    bottom of the loop back to 3 seconds. This is unrelated to


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Replace `workflow.DefaultVersion` to `1` in *Part D, 2*.

## Why?
<!-- Tell your future self why have you made these changes -->
It's a mistake in README, the `version` must be equal to `1`. See https://github.com/temporalio/edu-102-go-code/blob/37032994b3ea52d42452e9c4a33a943d3ec0b1a7/exercises/version-workflow/solution/workflow.go#L53

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
