### PR TITLE
Fix typo in the exercise "testing-code" workflow implementation

### DIFF
--- a/exercises/testing-code/practice/workflow.go
+++ b/exercises/testing-code/practice/workflow.go
@@ -42,7 +42,7 @@ func SayHelloGoodbye(ctx workflow.Context, input TranslationWorkflowInput) (Tran
 	if err != nil {
 		return TranslationWorkflowOutput{}, err
 	}
-	goodbyeMessage := fmt.Sprintf("%s; %s", goodbyeResult.Translation, input.Name)
+	goodbyeMessage := fmt.Sprintf("%s, %s", goodbyeResult.Translation, input.Name)
 
 	output := TranslationWorkflowOutput{
 		HelloMessage:   helloMessage,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
There is a typo in the `testing-code` exercise that caused a mismatch with the test assertion

## Why?
<!-- Tell your future self why have you made these changes -->
Test cases will be always failed in the exercise

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here --> (None)

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Run through the steps in the exercise [readme](https://github.com/temporalio/edu-102-go-code/blob/main/exercises/testing-code/README.md).


3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io --> None
