### PR TITLE
Fix issue in workflow.go of Testing Code exercise

### DIFF
--- a/exercises/testing-code/practice/workflow.go
+++ b/exercises/testing-code/practice/workflow.go
@@ -42,7 +42,7 @@ func SayHelloGoodbye(ctx workflow.Context, input TranslationWorkflowInput) (Tran
 	if err != nil {
 		return TranslationWorkflowOutput{}, err
 	}
-	goodbyeMessage := fmt.Sprintf("%s; %s", goodbyeResult.Translation, input.Name)
+	goodbyeMessage := fmt.Sprintf("%s, %s", goodbyeResult.Translation, input.Name)
 
 	output := TranslationWorkflowOutput{
 		HelloMessage:   helloMessage,


### PR DESCRIPTION
...activity where translation was adding a semicolon to the goodbye output instead of a comma

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
The Testing Code activity includes an activity which was mistakenly adding a semicolon instead of a comma to the translation goodbye output. This was only observed in the practice section and not the solution.

## Why?
<!-- Tell your future self why have you made these changes -->
Ensures that the instructions for the activity yield the expected results.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Compared against the workflow.go impl in the solution to ensure this was the intended behavior.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
