### PR TITLE
EDU-3784: Check for updated message from Activity

### DIFF
--- a/exercises/debug-activity/practice/activity_test.go
+++ b/exercises/debug-activity/practice/activity_test.go
@@ -87,5 +87,5 @@ func TestSendBillFailsWithNegativeAmount(t *testing.T) {
 
 	_, err := env.ExecuteActivity(SendBill, input)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid charge amount: -1000")
+	assert.Contains(t, err.Error(), "invalid charge amount: -1000 (< 1)")
 }

--- a/exercises/debug-activity/solution/activity_test.go
+++ b/exercises/debug-activity/solution/activity_test.go
@@ -109,5 +109,5 @@ func TestSendBillFailsWithNegativeAmount(t *testing.T) {
 
 	_, err := env.ExecuteActivity(SendBill, input)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid charge amount: -1000 (must be above zero)")
+	assert.Contains(t, err.Error(), "invalid charge amount: -1000 (< 1)")
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
I updated the test case assertion to match the error message returned by the Activity function, which I had modified in a previous commit.

## Why?
In EDU-665 (T102: Replace fmt.Sprintf + errors.New with fmt.Errorf Call), I [changed](https://github.com/temporalio/edu-102-go-code/commit/219f182c9f8e4099bbb6bce709a554da42c2db51) the text of an error message returned by an Activity function, but did not think to update the corresponding test case. This fixes that oversight.

## Checklist
<!--- add/delete as needed --->

1. Closes EDU-3784

2. How was this tested: I ran `go test` in the `solution` directory for this exercise prior to the change, observing that the test failed. I updated the test as per this commit and observed that the test subsequently passed. I made the same update to the `practice` version of the code.

3. Any docs updates needed? No