### PR TITLE
VLN-1676: remediate unpinned-github-actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
       - name: Print build information
         run: "echo head_ref: ${{ github.head_ref }}, ref: ${{ github.ref }}"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           submodules: recursive
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "1.22"
 


### PR DESCRIPTION
> 🏕️ This pull request was created by [camper](https://github.com/temporalio/camper), an automated security campaign tool.

## Finding

<table>
  <tr><td><strong>Rule</strong></td><td><code>unpinned-github-actions</code></td></tr>
  <tr><td><strong>Severity</strong></td><td>MEDIUM</td></tr>
  <tr><td><strong>Repository</strong></td><td><code>temporalio/edu-102-go-code</code></td></tr>
  <tr><td><strong>Ticket</strong></td><td><a href="https://temporalio.atlassian.net/browse/VLN-1676">VLN-1676</a></td></tr>
</table>

## Summary

🤠 [Deputy](https://github.com/temporalio/deputy) pinned dependencies to immutable references.

- Total refs: 2
- Pinned refs: 2

Changed references:
- `actions/setup-go`: `v5` -> `40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0`
- `actions/checkout`: `v4` -> `11d5960a326750d5838078e36cf38b85af677262 # v4.4.0`

## Instructions

- **Approve** to merge this fix
- **Request changes** to trigger a new remediation attempt
- `/camper rebase` — rebase onto the base branch
- `/camper close` — close this PR without merging
- `/camper retry` — regenerate the fix from scratch against the current base